### PR TITLE
Adding cities endpoints

### DIFF
--- a/src/helpers/index.js
+++ b/src/helpers/index.js
@@ -1,1 +1,1 @@
-export { neo4jSession } from './neo4j.js';
+export { neo4jSession, createObject } from './neo4j.js';

--- a/src/helpers/neo4j.js
+++ b/src/helpers/neo4j.js
@@ -1,5 +1,6 @@
 import n4 from 'neo4j-driver';
 import config from '../config';
+// import util from 'util';
 
 const neo4j = n4.v1;
 const driver = neo4j.driver('http://localhost', neo4j.auth.basic(config.neo4j.username, config.neo4j.password));
@@ -16,14 +17,11 @@ export const neo4jSession = () => {
 // CreateObject
 export const createObject = (results) => {
   const dataList = [];
-  results.records.forEach((record) => {
+  // console.log(util.inspect(results, { colors: true, depth: 5 }));
+  results.forEach((record) => {
     const item = {};
     record.keys.forEach((el, i) => {
-      if (record.keys[i] === 'id') {
-        item[record.keys[i]] = record._fields[i].low;
-      } else {
-        item[record.keys[i]] = record._fields[i];
-      }
+      item[record.keys[i]] = record._fields[i];
     });
     dataList.push(item);
   });

--- a/src/helpers/neo4j.js
+++ b/src/helpers/neo4j.js
@@ -11,3 +11,25 @@ export const neo4jSession = () => {
   }
   return session;
 };
+
+
+// CreateObject
+export const createObject = (results) => {
+  const dataList = [];
+  results.records.forEach((record) => {
+    const item = {};
+    record.keys.forEach((el, i) => {
+      if (record.keys[i] === 'id') {
+        item[record.keys[i]] = record._fields[i].low;
+      } else {
+        item[record.keys[i]] = record._fields[i];
+      }
+    });
+    dataList.push(item);
+  });
+  return dataList;
+};
+
+// const isInArray = (key, arr) => {
+//   return (arr.indexOf(key) !== -1);
+// };

--- a/src/index.js
+++ b/src/index.js
@@ -5,12 +5,12 @@ import schema from './schema';
 express().use('/', graphqlHTTP({
   schema,
   pretty: true,
-})).listen(3000);
+})).listen(3009);
 
 if (process.env.NODE_ENV === 'development') {
   express().use('/', graphqlHTTP({
     schema,
     pretty: true,
     graphiql: true,
-  })).listen(3001);
+  })).listen(3010);
 }

--- a/src/models/city.js
+++ b/src/models/city.js
@@ -1,12 +1,16 @@
-import { neo4jSession, createObject } from '../helpers';
+import {
+  neo4jSession,
+  createObject,
+} from '../helpers';
 
 const getCityByIdAsync = (id) => {
   const query = `
-    MATCH (c:City)
+    MATCH (c:City)-[:IS_FROM]->(co:Country)
     WHERE ID(c) = toInt({id})
     RETURN
       ID(c) as id,
-      c.name as name
+      c.name as name,
+      co as Country
   `;
   const params = {
     id,
@@ -19,7 +23,7 @@ const getCityByIdAsync = (id) => {
         if (results.records.length < 1) {
           reject('No cities found');
         } else {
-          const dataList = createObject(results);
+          const dataList = createObject(results.records);
           resolve(dataList[0]);
         }
       })
@@ -39,11 +43,12 @@ export async function getCityById(name) {
 const getCityByNameAsync = (name) => {
   const query = `
     MATCH (c:City {
-      name: {name}
-    })
+      nameLower: lower({name})
+    })-[:IS_FROM]->(co:Country)
     RETURN
       ID(c) as id,
-      c.name as name
+      c.name as name,
+      co as Country
   `;
   const params = {
     name,
@@ -55,7 +60,7 @@ const getCityByNameAsync = (name) => {
         if (results.records.length < 1) {
           reject('No cities found');
         } else {
-          const dataList = createObject(results);
+          const dataList = createObject(results.records);
           resolve(dataList[0]);
         }
       })
@@ -75,10 +80,11 @@ export async function getCityByName(name) {
 
 const getCitiesAsync = () => {
   const query = `
-    MATCH (c:City)
+    MATCH (c:City)-[:IS_FROM]->(co:Country)
     RETURN
       ID(c) as id,
-      c.name as name
+      c.name as name,
+      co as Country
   `;
   return new Promise((resolve, reject) => {
     neo4jSession()
@@ -87,7 +93,7 @@ const getCitiesAsync = () => {
         if (results.records.length < 1) {
           reject('No cities found');
         } else {
-          const dataList = createObject(results);
+          const dataList = createObject(results.records);
           resolve(dataList);
         }
       })
@@ -98,6 +104,85 @@ const getCitiesAsync = () => {
 export async function getCities() {
   try {
     return await getCitiesAsync();
+  } catch (err) {
+    console.error(err);
+    return err;
+  }
+}
+//
+// c.isoCode as isoCode,
+// c.name as name,
+// c.fipsCode as code,
+// c.tld as tld,
+// ID(c) as id,
+// ct as cities
+
+export const getCitiesByCountryAsync = (countryId) => {
+  const query = `
+      MATCH (c:City)-[:IS_FROM]->(co:Country)
+      WHERE ID(co) = toInt({id})
+      RETURN
+        ID(c) as id,
+        c.name as name,
+        co as Country
+      LIMIT 3
+    `;
+  const params = {
+    id: countryId,
+  };
+  return new Promise((resolve, reject) => {
+    neo4jSession()
+      .run(query, params)
+      .then((results) => {
+        if (results.records.length < 1) {
+          reject('No cities found');
+        } else {
+          const dataList = createObject(results.records);
+          resolve(dataList);
+        }
+      })
+      .catch(reject);
+  });
+};
+
+export async function getCitiesByCountry(countryId) {
+  try {
+    return await getCitiesByCountryAsync(countryId);
+  } catch (err) {
+    console.error(err);
+    return err;
+  }
+}
+
+
+export const getCitiesContainingTextAsync = (name) => {
+  const query = `
+    MATCH (c:City)-[:IS_FROM]->(co:Country)
+    WHERE c.nameLower =~ '(?i).*${name}.*'
+    RETURN
+      ID(c) as id,
+      c.name as name,
+      co as Country
+    `;
+  return new Promise((resolve, reject) => {
+    neo4jSession()
+      .run(query)
+      .then((results) => {
+        if (results.records.length < 1) {
+          reject('No cities found');
+        } else {
+          const dataList = createObject(results.records);
+          console.log(dataList);
+          resolve(dataList);
+        }
+      })
+      .catch(reject);
+  });
+};
+
+export async function getCitiesContainingText(text) {
+  try {
+    return await getCitiesContainingTextAsync(text);
   } catch (err) {
     console.error(err);
     return err;

--- a/src/models/city.js
+++ b/src/models/city.js
@@ -1,30 +1,93 @@
-import { neo4jSession } from '../helpers';
+import { neo4jSession, createObject } from '../helpers';
+
+const getCityByIdAsync = (id) => {
+  const query = `
+    MATCH (c:City)
+    WHERE ID(c) = toInt({id})
+    RETURN
+      ID(c) as id,
+      c.name as name
+  `;
+  const params = {
+    id,
+  };
+
+  return new Promise((resolve, reject) => {
+    neo4jSession()
+      .run(query, params)
+      .then((results) => {
+        if (results.records.length < 1) {
+          reject('No cities found');
+        } else {
+          const dataList = createObject(results);
+          resolve(dataList[0]);
+        }
+      })
+      .catch(reject);
+  });
+};
+
+export async function getCityById(name) {
+  try {
+    return await getCityByIdAsync(name);
+  } catch (err) {
+    console.error(err);
+    return err;
+  }
+}
+
+const getCityByNameAsync = (name) => {
+  const query = `
+    MATCH (c:City {
+      name: {name}
+    })
+    RETURN
+      ID(c) as id,
+      c.name as name
+  `;
+  const params = {
+    name,
+  };
+  return new Promise((resolve, reject) => {
+    neo4jSession()
+      .run(query, params)
+      .then((results) => {
+        if (results.records.length < 1) {
+          reject('No cities found');
+        } else {
+          const dataList = createObject(results);
+          resolve(dataList[0]);
+        }
+      })
+      .catch(reject);
+  });
+};
+
+export async function getCityByName(name) {
+  try {
+    return await getCityByNameAsync(name);
+  } catch (err) {
+    console.error(err);
+    return err;
+  }
+}
+
 
 const getCitiesAsync = () => {
   const query = `
     MATCH (c:City)
     RETURN
-      c
+      ID(c) as id,
+      c.name as name
   `;
   return new Promise((resolve, reject) => {
     neo4jSession()
       .run(query)
       .then((results) => {
         if (results.records.length < 1) {
-          reject('No coworks found');
+          reject('No cities found');
         } else {
-          const dataList = [];
-          results.records.forEach((record) => {
-            const item = {};
-            record.keys.forEach((el, i) => {
-              if (record.keys[i] === 'id') {
-                item[record.keys[i]] = record._fields[i].low;
-              } else {
-                item[record.keys[i]] = record._fields[i];
-              }
-            });
-            dataList.push(item);
-          });
+          const dataList = createObject(results);
           resolve(dataList);
         }
       })
@@ -34,8 +97,7 @@ const getCitiesAsync = () => {
 
 export async function getCities() {
   try {
-    const citiesList = await getCitiesAsync();
-    return citiesList;
+    return await getCitiesAsync();
   } catch (err) {
     console.error(err);
     return err;

--- a/src/models/country.js
+++ b/src/models/country.js
@@ -1,19 +1,19 @@
-import { neo4jSession } from '../helpers';
+import { neo4jSession, createObject } from '../helpers';
 
 export const getCountryByIdAsync = (id) => {
   const query = `
     MATCH (c:Country)
-    WHERE ID(c)= {id}
+    WHERE ID(c) = toInt({id})
     RETURN
-    c.code
-    ID(a) as id,
-    a.country as country,
-    a.city as city,
-    a.number as number,
-    a.phone as phoneNumber,
-    a.lat as latitud,
-    a.long as longitud,
-    a.url as webpage
+      c.code,
+      ID(c) as id,
+      c.country as country,
+      c.city as city,
+      c.number as number,
+      c.phone as phoneNumber,
+      c.lat as latitud,
+      c.long as longitud,
+      c.url as webpage
   `;
   const params = {
     id,
@@ -22,19 +22,11 @@ export const getCountryByIdAsync = (id) => {
     neo4jSession()
       .run(query, params)
       .then((results) => {
-        const record = results.records[0];
         if (results.records.length < 1) {
-          reject('No coworks found');
+          reject('No cities found');
         } else {
-          const cowork = {};
-          record.keys.forEach((el, i) => {
-            if (record.keys[i] === 'id') {
-              cowork[record.keys[i]] = record._fields[i].low;
-            } else {
-              cowork[record.keys[i]] = record._fields[i];
-            }
-          });
-          resolve(cowork);
+          const dataList = createObject(results);
+          resolve(dataList[0]);
         }
       })
       .catch(reject);
@@ -44,6 +36,60 @@ export const getCountryByIdAsync = (id) => {
 export async function getCountryById(id) {
   try {
     const countryById = await getCountryByIdAsync(id);
+    return countryById;
+  } catch (err) {
+    console.error(err);
+    return err;
+  }
+}
+
+
+
+
+export const getCountryCitiesAsync = (id) => {
+  const query = `
+    MATCH (c:Country)-[:HAS]->(ct:City)
+    WHERE ID(c) = 220
+    RETURN
+      c.isoCode as isoCode,
+      c.name as name,
+      c.fipsCode as code,
+      c.tld as tld,
+      ID(c) as id,
+      ct as cities
+  `;
+  const params = {
+    id,
+  };
+  return new Promise((resolve, reject) => {
+    neo4jSession()
+      .run(query, params)
+      .then((results) => {
+        if (results.records.length < 1) {
+          reject('No cities found');
+        } else {
+          const dataList = [];
+          results.records.forEach((record) => {
+            const item = {};
+            record.keys.forEach((el, i) => {
+              if (record.keys[i] === 'id') {
+                item[record.keys[i]] = record._fields[i].low;
+              } else {
+                item[record.keys[i]] = record._fields[i];
+              }
+            });
+            dataList.push(item);
+          });
+          resolve(dataList[0]);
+        }
+      })
+      .catch(reject);
+  });
+};
+
+export async function getCountryCities(id) {
+  try {
+    const countryById = await getCountryCitiesAsync(id);
     return countryById;
   } catch (err) {
     console.error(err);
@@ -73,20 +119,9 @@ const getCountryByNameAsync = (name) => {
       .run(query, params)
       .then((results) => {
         if (results.records.length < 1) {
-          reject('No coworks found');
+          reject('No countries found');
         } else {
-          const dataList = [];
-          results.records.forEach((record) => {
-            const item = {};
-            record.keys.forEach((el, i) => {
-              if (record.keys[i] === 'id') {
-                item[record.keys[i]] = record._fields[i].low;
-              } else {
-                item[record.keys[i]] = record._fields[i];
-              }
-            });
-            dataList.push(item);
-          });
+          const dataList = createObject(results);
           resolve(dataList[0]);
         }
       })
@@ -120,20 +155,9 @@ const getCountriesAsync = () => {
       .run(query)
       .then((results) => {
         if (results.records.length < 1) {
-          reject('No coworks found');
+          reject('No countries found');
         } else {
-          const dataList = [];
-          results.records.forEach((record) => {
-            const item = {};
-            record.keys.forEach((el, i) => {
-              if (record.keys[i] === 'id') {
-                item[record.keys[i]] = record._fields[i].low;
-              } else {
-                item[record.keys[i]] = record._fields[i];
-              }
-            });
-            dataList.push(item);
-          });
+          const dataList = createObject(results);
           resolve(dataList);
         }
       })

--- a/src/models/country.js
+++ b/src/models/country.js
@@ -25,7 +25,7 @@ export const getCountryByIdAsync = (id) => {
         if (results.records.length < 1) {
           reject('No cities found');
         } else {
-          const dataList = createObject(results);
+          const dataList = createObject(results.records);
           resolve(dataList[0]);
         }
       })
@@ -43,65 +43,10 @@ export async function getCountryById(id) {
   }
 }
 
-
-
-
-export const getCountryCitiesAsync = (id) => {
-  const query = `
-    MATCH (c:Country)-[:HAS]->(ct:City)
-    WHERE ID(c) = 220
-    RETURN
-      c.isoCode as isoCode,
-      c.name as name,
-      c.fipsCode as code,
-      c.tld as tld,
-      ID(c) as id,
-      ct as cities
-  `;
-  const params = {
-    id,
-  };
-  return new Promise((resolve, reject) => {
-    neo4jSession()
-      .run(query, params)
-      .then((results) => {
-        if (results.records.length < 1) {
-          reject('No cities found');
-        } else {
-          const dataList = [];
-          results.records.forEach((record) => {
-            const item = {};
-            record.keys.forEach((el, i) => {
-              if (record.keys[i] === 'id') {
-                item[record.keys[i]] = record._fields[i].low;
-              } else {
-                item[record.keys[i]] = record._fields[i];
-              }
-            });
-            dataList.push(item);
-          });
-          resolve(dataList[0]);
-        }
-      })
-      .catch(reject);
-  });
-};
-
-export async function getCountryCities(id) {
-  try {
-    const countryById = await getCountryCitiesAsync(id);
-    return countryById;
-  } catch (err) {
-    console.error(err);
-    return err;
-  }
-}
-
-
 const getCountryByNameAsync = (name) => {
   const query = `
     MATCH (c:Country {
-      name: {name}
+      nameLower: lower({name})
     })
     RETURN
       ID(c) as id,
@@ -121,7 +66,7 @@ const getCountryByNameAsync = (name) => {
         if (results.records.length < 1) {
           reject('No countries found');
         } else {
-          const dataList = createObject(results);
+          const dataList = createObject(results.records);
           resolve(dataList[0]);
         }
       })
@@ -157,7 +102,7 @@ const getCountriesAsync = () => {
         if (results.records.length < 1) {
           reject('No countries found');
         } else {
-          const dataList = createObject(results);
+          const dataList = createObject(results.records);
           resolve(dataList);
         }
       })

--- a/src/models/cowork.js
+++ b/src/models/cowork.js
@@ -1,19 +1,19 @@
-import { neo4jSession } from '../helpers';
+import { neo4jSession, createObject } from '../helpers';
 
 export const getCoworkByIdAsync = (id) => {
   const query = `
-    MATCH (a:Cowork)
-    WHERE ID(a)= {id}
+    MATCH (c:Cowork)
+    WHERE ID(c) = toInt({id})
     RETURN
-    a.name as name,
-    ID(a) as id,
-    a.country as country,
-    a.city as city,
-    a.number as number,
-    a.phone as phoneNumber,
-    a.lat as latitud,
-    a.long as longitud,
-    a.url as webpage
+    c.name as name,
+    ID(c) as id,
+    c.country as country,
+    c.city as city,
+    c.number as number,
+    c.phone as phoneNumber,
+    c.lat as latitud,
+    c.long as longitud,
+    c.url as webpage
   `;
   const params = {
     id,
@@ -22,19 +22,11 @@ export const getCoworkByIdAsync = (id) => {
     neo4jSession()
       .run(query, params)
       .then((results) => {
-        const record = results.records[0];
         if (results.records.length < 1) {
           reject('No coworks found');
         } else {
-          const cowork = {};
-          record.keys.forEach((el, i) => {
-            if (record.keys[i] === 'id') {
-              cowork[record.keys[i]] = record._fields[i].low;
-            } else {
-              cowork[record.keys[i]] = record._fields[i];
-            }
-          });
-          resolve(cowork);
+          const dataList = createObject(results);
+          resolve(dataList[0]);
         }
       })
       .catch(reject);
@@ -54,19 +46,19 @@ export async function getCoworkById(id) {
 
 const getCoworkByNameAsync = (name) => {
   const query = `
-    MATCH (a:Cowork {
+    MATCH (c:Cowork {
       name: {name}
     })
     RETURN
-    a.name as name,
-    ID(a) as id,
-    a.country as country,
-    a.city as city,
-    a.number as number,
-    a.phone as phoneNumber,
-    a.lat as latitud,
-    a.long as longitud,
-    a.url as webpage
+    c.name as name,
+    ID(c) as id,
+    c.country as country,
+    c.city as city,
+    c.number as number,
+    c.phone as phoneNumber,
+    c.lat as latitud,
+    c.long as longitud,
+    c.url as webpage
     LIMIT 1
   `;
   const params = {
@@ -79,19 +71,8 @@ const getCoworkByNameAsync = (name) => {
         if (results.records.length < 1) {
           reject('No coworks found');
         } else {
-          const coworks = [];
-          results.records.forEach((record) => {
-            const cowork = {};
-            record.keys.forEach((el, i) => {
-              if (record.keys[i] === 'id') {
-                cowork[record.keys[i]] = record._fields[i].low;
-              } else {
-                cowork[record.keys[i]] = record._fields[i];
-              }
-            });
-            coworks.push(cowork);
-          });
-          resolve(coworks[0]);
+          const dataList = createObject(results);
+          resolve(dataList[0]);
         }
       })
       .catch(reject);
@@ -111,17 +92,17 @@ export async function getCoworkByName(name) {
 
 const getCoworksAsync = () => {
   const query = `
-    MATCH (a:Cowork)
+    MATCH (c:Cowork)
     RETURN
-      a.name as name,
-      ID(a) as id,
-      a.country as country,
-      a.city as city,
-      a.number as number,
-      a.phone as phoneNumber,
-      a.lat as latitud,
-      a.long as longitud,
-      a.url as webpage
+      c.name as name,
+      ID(c) as id,
+      c.country as country,
+      c.city as city,
+      c.number as number,
+      c.phone as phoneNumber,
+      c.lat as latitud,
+      c.long as longitud,
+      c.url as webpage
   `;
   return new Promise((resolve, reject) => {
     neo4jSession()
@@ -130,19 +111,8 @@ const getCoworksAsync = () => {
         if (results.records.length < 1) {
           reject('No coworks found');
         } else {
-          const coworks = [];
-          results.records.forEach((record) => {
-            const cowork = {};
-            record.keys.forEach((el, i) => {
-              if (record.keys[i] === 'id') {
-                cowork[record.keys[i]] = record._fields[i].low;
-              } else {
-                cowork[record.keys[i]] = record._fields[i];
-              }
-            });
-            coworks.push(cowork);
-          });
-          resolve(coworks);
+          const dataList = createObject(results);
+          resolve(dataList);
         }
       })
       .catch(reject);

--- a/src/models/cowork.js
+++ b/src/models/cowork.js
@@ -25,7 +25,7 @@ export const getCoworkByIdAsync = (id) => {
         if (results.records.length < 1) {
           reject('No coworks found');
         } else {
-          const dataList = createObject(results);
+          const dataList = createObject(results.records);
           resolve(dataList[0]);
         }
       })
@@ -47,7 +47,7 @@ export async function getCoworkById(id) {
 const getCoworkByNameAsync = (name) => {
   const query = `
     MATCH (c:Cowork {
-      name: {name}
+      nameLower: lower({name})
     })
     RETURN
     c.name as name,
@@ -71,7 +71,7 @@ const getCoworkByNameAsync = (name) => {
         if (results.records.length < 1) {
           reject('No coworks found');
         } else {
-          const dataList = createObject(results);
+          const dataList = createObject(results.records);
           resolve(dataList[0]);
         }
       })
@@ -111,7 +111,7 @@ const getCoworksAsync = () => {
         if (results.records.length < 1) {
           reject('No coworks found');
         } else {
-          const dataList = createObject(results);
+          const dataList = createObject(results.records);
           resolve(dataList);
         }
       })

--- a/src/models/index.js
+++ b/src/models/index.js
@@ -1,3 +1,3 @@
 export { getCoworkById, getCoworkByName, getCoworks } from './cowork';
-export { getCityByName, getCityById, getCities } from './city';
-export { getCountryByName, getCountryById, getCountries, getCountryCities } from './country';
+export { getCityByName, getCityById, getCities, getCitiesByCountry, getCitiesContainingText } from './city';
+export { getCountryByName, getCountryById, getCountries } from './country';

--- a/src/models/index.js
+++ b/src/models/index.js
@@ -1,3 +1,3 @@
 export { getCoworkById, getCoworkByName, getCoworks } from './cowork';
-export { getCityById, getCityByName, getCities } from './city';
-export { getCountryByName, getCountryById, getCountries } from './country';
+export { getCityByName, getCityById, getCities } from './city';
+export { getCountryByName, getCountryById, getCountries, getCountryCities } from './country';

--- a/src/queries/city.js
+++ b/src/queries/city.js
@@ -1,6 +1,6 @@
 import { GraphQLString, GraphQLNonNull, GraphQLInt } from 'graphql';
 import { cityType, cityListType } from '../types';
-import { getCityByName, getCityById, getCities } from '../models';
+import { getCityByName, getCityById, getCities, getCitiesByCountry, getCitiesContainingText } from '../models';
 
 export const cityByName = {
   name: 'cityByName',
@@ -14,6 +14,17 @@ export const cityByName = {
   resolve: (root, { name }) => getCityByName(name),
 };
 
+export const citiesContainingText = {
+  name: 'citiesContainingText',
+  type: cityListType,
+  args: {
+    name: {
+      type: new GraphQLNonNull(GraphQLString),
+      description: 'City Display Name',
+    },
+  },
+  resolve: (root, { name }) => getCitiesContainingText(name),
+};
 
 export const cityById = {
   name: 'cityById',
@@ -32,4 +43,17 @@ export const cityList = {
   description: 'Returns a list of cities', // TODO: define this query (Geolocated? by popularity?)
   type: cityListType,
   resolve: () => getCities(),
+};
+
+export const citiesByCountry = {
+  name: 'citiesByCountry',
+  description: 'List of cities by country',
+  type: cityListType,
+  args: {
+    countryId: {
+      type: new GraphQLNonNull(GraphQLInt),
+      description: 'Unique Country id to filter cities',
+    },
+  },
+  resolve: (root, { countryId }) => getCitiesByCountry(countryId),
 };

--- a/src/queries/city.js
+++ b/src/queries/city.js
@@ -1,4 +1,4 @@
-import { GraphQLString, GraphQLNonNull } from 'graphql';
+import { GraphQLString, GraphQLNonNull, GraphQLInt } from 'graphql';
 import { cityType, cityListType } from '../types';
 import { getCityByName, getCityById, getCities } from '../models';
 
@@ -20,7 +20,7 @@ export const cityById = {
   type: cityType,
   args: {
     id: {
-      type: new GraphQLNonNull(GraphQLString),
+      type: new GraphQLNonNull(GraphQLInt),
       description: 'Unique City ID',
     },
   },

--- a/src/queries/country.js
+++ b/src/queries/country.js
@@ -1,6 +1,6 @@
-import { GraphQLString, GraphQLNonNull } from 'graphql';
+import { GraphQLString, GraphQLNonNull, GraphQLInt } from 'graphql';
 import { countryType, countryListType } from '../types';
-import { getCountryById, getCountryByName, getCountries } from '../models';
+import { getCountryById, getCountryByName, getCountries, getCountryCities } from '../models';
 
 export const countryByName = {
   name: 'countryByName',
@@ -20,11 +20,24 @@ export const countryById = {
   type: countryType,
   args: {
     id: {
-      type: new GraphQLNonNull(GraphQLString),
+      type: new GraphQLNonNull(GraphQLInt),
       description: 'Unique Country ID',
     },
   },
   resolve: (root, { id }) => getCountryById(id),
+};
+
+export const countryCities = {
+  name: 'countryList',
+  description: 'Returns a list of countries', // TODO: define this query (Geolocated? by popularity?)
+  type: countryType,
+  args: {
+    id: {
+      type: new GraphQLNonNull(GraphQLInt),
+      description: 'Unique Country ID',
+    },
+  },
+  resolve: (root, { id }) => getCountryCities(id),
 };
 
 export const countryList = {

--- a/src/queries/country.js
+++ b/src/queries/country.js
@@ -1,6 +1,6 @@
 import { GraphQLString, GraphQLNonNull, GraphQLInt } from 'graphql';
 import { countryType, countryListType } from '../types';
-import { getCountryById, getCountryByName, getCountries, getCountryCities } from '../models';
+import { getCountryById, getCountryByName, getCountries } from '../models';
 
 export const countryByName = {
   name: 'countryByName',
@@ -25,19 +25,6 @@ export const countryById = {
     },
   },
   resolve: (root, { id }) => getCountryById(id),
-};
-
-export const countryCities = {
-  name: 'countryList',
-  description: 'Returns a list of countries', // TODO: define this query (Geolocated? by popularity?)
-  type: countryType,
-  args: {
-    id: {
-      type: new GraphQLNonNull(GraphQLInt),
-      description: 'Unique Country ID',
-    },
-  },
-  resolve: (root, { id }) => getCountryCities(id),
 };
 
 export const countryList = {

--- a/src/queries/cowork.js
+++ b/src/queries/cowork.js
@@ -1,4 +1,4 @@
-import { GraphQLString, GraphQLNonNull } from 'graphql';
+import { GraphQLString, GraphQLNonNull, GraphQLInt } from 'graphql';
 import { coworkType, coworkListType } from '../types';
 import { getCoworkById, getCoworkByName, getCoworks } from '../models';
 
@@ -19,7 +19,7 @@ export const coworkById = {
   type: coworkType,
   args: {
     id: {
-      type: new GraphQLNonNull(GraphQLString),
+      type: new GraphQLNonNull(GraphQLInt),
       description: 'Unique Cowork ID',
     },
   },

--- a/src/queries/index.js
+++ b/src/queries/index.js
@@ -1,3 +1,3 @@
 export { coworkByName, coworkById, coworkList } from './cowork';
-export { countryByName, countryById, countryList, countryCities } from './country';
-export { cityByName, cityById, cityList } from './city';
+export { countryByName, countryById, countryList } from './country';
+export { cityByName, cityById, cityList, citiesByCountry, citiesContainingText } from './city';

--- a/src/queries/index.js
+++ b/src/queries/index.js
@@ -1,3 +1,3 @@
 export { coworkByName, coworkById, coworkList } from './cowork';
-export { countryByName, countryById, countryList } from './country';
+export { countryByName, countryById, countryList, countryCities } from './country';
 export { cityByName, cityById, cityList } from './city';

--- a/src/schema/index.js
+++ b/src/schema/index.js
@@ -1,8 +1,19 @@
-import { GraphQLSchema, GraphQLObjectType } from 'graphql';
 import {
-  coworkByName, coworkById, coworkList,
-  countryByName, countryById, countryList,
-  cityByName, cityById, cityList, countryCities,
+  GraphQLSchema,
+  GraphQLObjectType,
+} from 'graphql';
+import {
+  coworkByName,
+  coworkById,
+  coworkList,
+  countryByName,
+  countryById,
+  countryList,
+  cityByName,
+  cityById,
+  cityList,
+  citiesByCountry,
+  citiesContainingText,
 } from '../queries';
 
 const schema = new GraphQLSchema({
@@ -15,10 +26,11 @@ const schema = new GraphQLSchema({
       countryByName,
       countryById,
       countryList,
-      countryCities,
       cityByName,
       cityById,
       cityList,
+      citiesByCountry,
+      citiesContainingText,
     }),
   }),
 });

--- a/src/schema/index.js
+++ b/src/schema/index.js
@@ -2,7 +2,7 @@ import { GraphQLSchema, GraphQLObjectType } from 'graphql';
 import {
   coworkByName, coworkById, coworkList,
   countryByName, countryById, countryList,
-  cityByName, cityById, cityList,
+  cityByName, cityById, cityList, countryCities,
 } from '../queries';
 
 const schema = new GraphQLSchema({
@@ -13,11 +13,12 @@ const schema = new GraphQLSchema({
       coworkByName,
       coworkById,
       countryByName,
-      // countryById,
+      countryById,
       countryList,
-      // cityByName,
-      // cityById,
-      // cityList,
+      countryCities,
+      cityByName,
+      cityById,
+      cityList,
     }),
   }),
 });

--- a/src/types/city.js
+++ b/src/types/city.js
@@ -1,4 +1,5 @@
 import { GraphQLString, GraphQLObjectType, GraphQLInt, GraphQLList } from 'graphql';
+import { countryType } from './country';
 
 export const cityType = new GraphQLObjectType({
   name: 'City',
@@ -10,6 +11,20 @@ export const cityType = new GraphQLObjectType({
     id: {
       type: GraphQLInt,
       description: 'Unique city ID',
+      resolve: (obj) => {
+        if (obj.id && obj.id.low) {
+          return obj.id.low;
+        }
+        return null;
+      },
+    },
+    country: {
+      type: countryType,
+      description: 'Country information for the city',
+      resolve: (obj) => {
+        const country = Object.assign({}, obj.Country.properties, { id: obj.Country.identity });
+        return country;
+      },
     },
   }),
 });

--- a/src/types/country.js
+++ b/src/types/country.js
@@ -1,4 +1,5 @@
 import { GraphQLString, GraphQLObjectType, GraphQLInt, GraphQLList } from 'graphql';
+import { cityListType } from './city';
 
 export const countryType = new GraphQLObjectType({
   name: 'Country',
@@ -22,6 +23,10 @@ export const countryType = new GraphQLObjectType({
     tld: {
       type: GraphQLString,
       description: 'TLD  for the country',
+    },
+    cities: {
+      type: new GraphQLList(cityListType),
+      description: 'Country Cities',
     },
   }),
 });

--- a/src/types/country.js
+++ b/src/types/country.js
@@ -10,7 +10,13 @@ export const countryType = new GraphQLObjectType({
     },
     id: {
       type: GraphQLInt,
-      description: 'Unique country ID',
+      description: 'Unique city ID',
+      resolve: (obj) => {
+        if (obj.id && obj.id.low) {
+          return obj.id.low;
+        }
+        return null;
+      },
     },
     code: {
       type: GraphQLString,

--- a/src/types/cowork.js
+++ b/src/types/cowork.js
@@ -10,6 +10,12 @@ export const coworkType = new GraphQLObjectType({
     id: {
       type: GraphQLInt,
       description: 'Unique Cowork ID',
+      resolve: (obj) => {
+        if (obj.id && obj.id.low) {
+          return obj.id.low;
+        }
+        return null;
+      },
     },
     phoneNumber: {
       type: GraphQLString,


### PR DESCRIPTION
Query by city Name
By city name, containing string.
Fixing other queries search by id (Countries and Coworks).
Extracting the response object creation from neo4j to a `createObject` helper function.
Helping with ID creation on all types.
Changing default por for API for development puroposes
